### PR TITLE
Add spring autoconfiguration for metrics and prometheus reporter

### DIFF
--- a/opentracing-metrics-prometheus-spring-autoconfigure/pom.xml
+++ b/opentracing-metrics-prometheus-spring-autoconfigure/pom.xml
@@ -35,12 +35,6 @@
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-metrics-prometheus</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-      	<exclusion>
-     	  <groupId>io.prometheus</groupId>
-     	  <artifactId>*</artifactId>
-      	</exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/opentracing-metrics-prometheus-spring-autoconfigure/pom.xml
+++ b/opentracing-metrics-prometheus-spring-autoconfigure/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>opentracing-metrics-parent</artifactId>
+    <groupId>io.opentracing.contrib</groupId>
+    <version>0.1.3-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>opentracing-metrics-prometheus-spring-autoconfigure</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-metrics-spring-autoconfigure</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-metrics-prometheus</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+      	<exclusion>
+     	  <groupId>io.prometheus</groupId>
+     	  <artifactId>*</artifactId>
+      	</exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_servlet</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>${version.javax.servlet-api}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <version>${version.org.springframework.boot}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.org.springframework.boot}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/opentracing-metrics-prometheus-spring-autoconfigure/src/main/java/io/opentracing/contrib/metrics/prometheus/spring/autoconfigure/PrometheusConfiguration.java
+++ b/opentracing-metrics-prometheus-spring-autoconfigure/src/main/java/io/opentracing/contrib/metrics/prometheus/spring/autoconfigure/PrometheusConfiguration.java
@@ -21,7 +21,6 @@ import org.springframework.context.annotation.Configuration;
 import io.prometheus.client.CollectorRegistry;
 
 @Configuration
-@ConditionalOnClass(value = {CollectorRegistry.class})
 public class PrometheusConfiguration {
 
     @Bean

--- a/opentracing-metrics-prometheus-spring-autoconfigure/src/main/java/io/opentracing/contrib/metrics/prometheus/spring/autoconfigure/PrometheusConfiguration.java
+++ b/opentracing-metrics-prometheus-spring-autoconfigure/src/main/java/io/opentracing/contrib/metrics/prometheus/spring/autoconfigure/PrometheusConfiguration.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.metrics.prometheus.spring.autoconfigure;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.prometheus.client.CollectorRegistry;
+
+@Configuration
+@ConditionalOnClass(value = {CollectorRegistry.class})
+public class PrometheusConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public CollectorRegistry defaultCollectorRegistry() {
+        return CollectorRegistry.defaultRegistry;
+    }
+}

--- a/opentracing-metrics-prometheus-spring-autoconfigure/src/main/java/io/opentracing/contrib/metrics/prometheus/spring/autoconfigure/PrometheusConfiguration.java
+++ b/opentracing-metrics-prometheus-spring-autoconfigure/src/main/java/io/opentracing/contrib/metrics/prometheus/spring/autoconfigure/PrometheusConfiguration.java
@@ -13,7 +13,6 @@
  */
 package io.opentracing.contrib.metrics.prometheus.spring.autoconfigure;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/opentracing-metrics-prometheus-spring-autoconfigure/src/main/java/io/opentracing/contrib/metrics/prometheus/spring/autoconfigure/PrometheusMetricsReporterConfiguration.java
+++ b/opentracing-metrics-prometheus-spring-autoconfigure/src/main/java/io/opentracing/contrib/metrics/prometheus/spring/autoconfigure/PrometheusMetricsReporterConfiguration.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.metrics.prometheus.spring.autoconfigure;
+
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.opentracing.contrib.metrics.MetricLabel;
+import io.opentracing.contrib.metrics.MetricsReporter;
+import io.opentracing.contrib.metrics.prometheus.PrometheusMetricsReporter;
+import io.prometheus.client.CollectorRegistry;
+
+@Configuration
+@ConditionalOnClass(value = {CollectorRegistry.class})
+public class PrometheusMetricsReporterConfiguration {
+
+    @Autowired
+    private CollectorRegistry collectorRegistry;
+
+    @Value("${OPENTRACING_METRICS_NAME:}")
+    private String metricsName;
+
+    @Autowired(required=false)
+    private Set<MetricLabel> metricLabels;
+
+    @Bean
+    public MetricsReporter prometheusMetricsReporter() {
+        PrometheusMetricsReporter.Builder builder = PrometheusMetricsReporter.newMetricsReporter();
+        if (metricsName != null && !metricsName.isEmpty()) {
+            builder.withName(metricsName);
+        }
+        builder.withCollectorRegistry(collectorRegistry);
+        if (metricLabels != null && !metricLabels.isEmpty()) {
+            for (MetricLabel label : metricLabels) {
+                builder.withCustomLabel(label);
+            }
+        }
+        return builder.build();
+    }
+
+}

--- a/opentracing-metrics-prometheus-spring-autoconfigure/src/main/java/io/opentracing/contrib/metrics/prometheus/spring/autoconfigure/PrometheusMetricsReporterConfiguration.java
+++ b/opentracing-metrics-prometheus-spring-autoconfigure/src/main/java/io/opentracing/contrib/metrics/prometheus/spring/autoconfigure/PrometheusMetricsReporterConfiguration.java
@@ -27,7 +27,6 @@ import io.opentracing.contrib.metrics.prometheus.PrometheusMetricsReporter;
 import io.prometheus.client.CollectorRegistry;
 
 @Configuration
-@ConditionalOnClass(value = {CollectorRegistry.class})
 public class PrometheusMetricsReporterConfiguration {
 
     @Autowired

--- a/opentracing-metrics-prometheus-spring-autoconfigure/src/main/java/io/opentracing/contrib/metrics/prometheus/spring/autoconfigure/PrometheusMetricsReporterConfiguration.java
+++ b/opentracing-metrics-prometheus-spring-autoconfigure/src/main/java/io/opentracing/contrib/metrics/prometheus/spring/autoconfigure/PrometheusMetricsReporterConfiguration.java
@@ -17,7 +17,6 @@ import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/opentracing-metrics-prometheus-spring-autoconfigure/src/main/java/io/opentracing/contrib/metrics/prometheus/spring/autoconfigure/PrometheusServletConfiguration.java
+++ b/opentracing-metrics-prometheus-spring-autoconfigure/src/main/java/io/opentracing/contrib/metrics/prometheus/spring/autoconfigure/PrometheusServletConfiguration.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.metrics.prometheus.spring.autoconfigure;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.MetricsServlet;
+
+@Configuration
+@ConditionalOnClass(value = {MetricsServlet.class})
+public class PrometheusServletConfiguration {
+
+    @Value("${OPENTRACING_METRICS_EXPORTER_HTTP_PATH:false}")
+    private String metricsPath;
+
+    @Bean
+    @ConditionalOnProperty(name="OPENTRACING_METRICS_EXPORTER_HTTP_PATH")
+    ServletRegistrationBean registerPrometheusExporterServlet(CollectorRegistry metricRegistry) {
+          return new ServletRegistrationBean(new MetricsServlet(metricRegistry), metricsPath);
+    }
+
+}

--- a/opentracing-metrics-prometheus-spring-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/opentracing-metrics-prometheus-spring-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,4 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+io.opentracing.contrib.metrics.prometheus.spring.autoconfigure.PrometheusConfiguration,\
+io.opentracing.contrib.metrics.prometheus.spring.autoconfigure.PrometheusMetricsReporterConfiguration,\
+io.opentracing.contrib.metrics.prometheus.spring.autoconfigure.PrometheusServletConfiguration

--- a/opentracing-metrics-prometheus-spring-autoconfigure/src/test/java/io/opentracing/contrib/metrics/prometheus/spring/autoconfigure/PrometheusMetricsReporterConfigurationTest.java
+++ b/opentracing-metrics-prometheus-spring-autoconfigure/src/test/java/io/opentracing/contrib/metrics/prometheus/spring/autoconfigure/PrometheusMetricsReporterConfigurationTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.metrics.prometheus.spring.autoconfigure;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import io.opentracing.contrib.api.SpanData;
+import io.opentracing.contrib.metrics.MetricsReporter;
+import io.opentracing.tag.Tags;
+import io.prometheus.client.Collector.MetricFamilySamples;
+import io.prometheus.client.CollectorRegistry;
+
+@SpringBootTest(
+        classes = {PrometheusMetricsReporterConfigurationTest.SpringConfiguration.class})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class PrometheusMetricsReporterConfigurationTest {
+
+    private static final CollectorRegistry testCollectorRegistry = new CollectorRegistry(); 
+
+    @Autowired
+    private MetricsReporter metricsReporter;
+
+    @Configuration
+    @EnableAutoConfiguration
+    public static class SpringConfiguration {
+        @Bean
+        public CollectorRegistry testCollectorRegistry() {
+            return testCollectorRegistry;
+        }
+    }
+
+    @Test
+    public void testMetricsReporter() {
+        MetricFamilySamples samples = testCollectorRegistry.metricFamilySamples().nextElement();
+        assertTrue(samples.samples.isEmpty());
+
+        SpanData metricSpanData=Mockito.mock(SpanData.class);
+        Mockito.when(metricSpanData.getOperationName()).thenReturn("testOp");
+        Map<String,Object> testTags = new HashMap<String,Object>();
+        testTags.put(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT);
+        Mockito.when(metricSpanData.getTags()).thenReturn(testTags);
+        Mockito.when(metricSpanData.getDuration()).thenReturn(500L);
+        metricsReporter.reportSpan(metricSpanData);
+
+        samples = testCollectorRegistry.metricFamilySamples().nextElement();
+        assertFalse(samples.samples.isEmpty());
+    }
+
+}

--- a/opentracing-metrics-prometheus-spring-autoconfigure/src/test/java/io/opentracing/contrib/metrics/prometheus/spring/autoconfigure/PrometheusMetricsReporterConfigurationWithNameTest.java
+++ b/opentracing-metrics-prometheus-spring-autoconfigure/src/test/java/io/opentracing/contrib/metrics/prometheus/spring/autoconfigure/PrometheusMetricsReporterConfigurationWithNameTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.metrics.prometheus.spring.autoconfigure;
+
+import static org.junit.Assert.*;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import io.opentracing.contrib.metrics.MetricsReporter;
+import io.prometheus.client.Collector.MetricFamilySamples;
+import io.prometheus.client.CollectorRegistry;
+
+@SpringBootTest(
+        classes = {PrometheusMetricsReporterConfigurationWithNameTest.SpringConfiguration.class})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class PrometheusMetricsReporterConfigurationWithNameTest {
+
+    private static final String METRICS_NAME = "testmetrics";
+
+    private static final CollectorRegistry testCollectorRegistry = new CollectorRegistry(); 
+
+    @Autowired
+    private MetricsReporter metricsReporter;
+
+    @Configuration
+    @EnableAutoConfiguration
+    public static class SpringConfiguration {
+        @Bean
+        public CollectorRegistry testCollectorRegistry() {
+            return testCollectorRegistry;
+        }
+    }
+
+    @BeforeClass
+    public static void init() {
+        System.setProperty("OPENTRACING_METRICS_NAME", METRICS_NAME);
+    }
+
+    @AfterClass
+    public static void close() {
+        System.clearProperty("OPENTRACING_METRICS_NAME");
+    }
+
+    @Test
+    public void testMetricsReporterName() {
+        assertNotNull(metricsReporter);
+
+        MetricFamilySamples samples = testCollectorRegistry.metricFamilySamples().nextElement();
+        assertEquals(METRICS_NAME, samples.name);
+    }
+
+}

--- a/opentracing-metrics-spring-autoconfigure/pom.xml
+++ b/opentracing-metrics-spring-autoconfigure/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>opentracing-metrics-parent</artifactId>
+    <groupId>io.opentracing.contrib</groupId>
+    <version>0.1.3-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>opentracing-metrics-spring-autoconfigure</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-api-extensions-tracer-spring-autoconfigure</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-metrics</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <version>${version.org.springframework.boot}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-metrics-prometheus</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+      	<exclusion>
+     	  <groupId>io.prometheus</groupId>
+     	  <artifactId>*</artifactId>
+      	</exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_servlet</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>${version.javax.servlet-api}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <version>${version.org.springframework.boot}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.org.springframework.boot}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/opentracing-metrics-spring-autoconfigure/pom.xml
+++ b/opentracing-metrics-spring-autoconfigure/pom.xml
@@ -46,12 +46,6 @@
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-metrics-prometheus</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-      	<exclusion>
-     	  <groupId>io.prometheus</groupId>
-     	  <artifactId>*</artifactId>
-      	</exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/opentracing-metrics-spring-autoconfigure/src/main/java/io/opentracing/contrib/metrics/spring/autoconfigure/MetricsTracerObserverConfiguration.java
+++ b/opentracing-metrics-spring-autoconfigure/src/main/java/io/opentracing/contrib/metrics/spring/autoconfigure/MetricsTracerObserverConfiguration.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.metrics.spring.autoconfigure;
+
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.opentracing.contrib.api.TracerObserver;
+import io.opentracing.contrib.metrics.MetricsObserver;
+import io.opentracing.contrib.metrics.MetricsReporter;
+
+@Configuration
+public class MetricsTracerObserverConfiguration {
+
+    @Autowired(required=false)
+    private Set<MetricsReporter> metricsReporters;
+
+    @Bean
+    public TracerObserver metricsTracerObserver() {
+        if (metricsReporters != null && !metricsReporters.isEmpty()) {
+            return new MetricsObserver(metricsReporters);
+        }
+        return null;
+    }
+
+}

--- a/opentracing-metrics-spring-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/opentracing-metrics-spring-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+io.opentracing.contrib.metrics.spring.autoconfigure.MetricsTracerObserverConfiguration

--- a/opentracing-metrics-spring-autoconfigure/src/test/java/io/opentracing/contrib/metrics/spring/autoconfigure/MetricsTracerObserverConfigurationNoReportersTest.java
+++ b/opentracing-metrics-spring-autoconfigure/src/test/java/io/opentracing/contrib/metrics/spring/autoconfigure/MetricsTracerObserverConfigurationNoReportersTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.metrics.spring.autoconfigure;
+
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import io.opentracing.contrib.api.TracerObserver;
+
+@SpringBootTest(
+        classes = {MetricsTracerObserverConfigurationNoReportersTest.SpringConfiguration.class})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class MetricsTracerObserverConfigurationNoReportersTest {
+
+    @Configuration
+    @EnableAutoConfiguration
+    public static class SpringConfiguration {
+    }
+
+    @Autowired(required=false)
+    protected TracerObserver tracerObserver;
+
+    @Test
+    public void testTracerObserverNoReporters() {
+        // No tracer observer should be found, as no metrics reporters have been defined
+        assertNull(tracerObserver);
+    }
+}

--- a/opentracing-metrics-spring-autoconfigure/src/test/java/io/opentracing/contrib/metrics/spring/autoconfigure/MetricsTracerObserverConfigurationWithReportersTest.java
+++ b/opentracing-metrics-spring-autoconfigure/src/test/java/io/opentracing/contrib/metrics/spring/autoconfigure/MetricsTracerObserverConfigurationWithReportersTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.metrics.spring.autoconfigure;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import io.opentracing.contrib.api.SpanData;
+import io.opentracing.contrib.api.TracerObserver;
+import io.opentracing.contrib.metrics.MetricsReporter;
+
+@SpringBootTest(
+        classes = {MetricsTracerObserverConfigurationWithReportersTest.SpringConfiguration.class})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class MetricsTracerObserverConfigurationWithReportersTest {
+
+    private static final MetricsReporter metricsReporter = Mockito.mock(MetricsReporter.class);
+
+    @Configuration
+    @EnableAutoConfiguration
+    public static class SpringConfiguration {
+        @Bean
+        public MetricsReporter reporter() {
+            return metricsReporter;
+        }
+    }
+
+    @Autowired(required=false)
+    protected TracerObserver tracerObserver;
+
+    @Test
+    public void testTracerObserverWithReporters() {
+        assertNotNull(tracerObserver);
+ 
+        SpanData spanData = Mockito.mock(SpanData.class);
+
+        tracerObserver.onStart(spanData).onFinish(spanData, System.currentTimeMillis());
+
+        Mockito.verify(metricsReporter).reportSpan(spanData);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,9 @@
 
   <modules>
     <module>opentracing-metrics</module>
+    <module>opentracing-metrics-spring-autoconfigure</module>
     <module>opentracing-metrics-prometheus</module>
+    <module>opentracing-metrics-prometheus-spring-autoconfigure</module>
   </modules>
 
   <properties>
@@ -67,10 +69,12 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.io.opentracing>0.30.0</version.io.opentracing>
-    <version.io.opentracing.contrib.opentracing-api-extensions>0.0.2</version.io.opentracing.contrib.opentracing-api-extensions>
+    <version.io.opentracing.contrib.opentracing-api-extensions>0.0.3</version.io.opentracing.contrib.opentracing-api-extensions>
     <version.io.prometheus>0.0.23</version.io.prometheus>
+    <version.javax.servlet-api>3.1.0</version.javax.servlet-api>
     <version.junit>4.12</version.junit>
     <version.org.mockito-mockito-all>1.10.19</version.org.mockito-mockito-all>
+    <version.org.springframework.boot>1.4.1.RELEASE</version.org.springframework.boot>
 
     <version.io.takari-maven>0.3.4</version.io.takari-maven>
     <version.io.zikin.centralsync-maven-plugin>0.1.0</version.io.zikin.centralsync-maven-plugin>
@@ -107,6 +111,11 @@
       <dependency>
         <groupId>io.opentracing.contrib</groupId>
         <artifactId>opentracing-api-extensions-tracer</artifactId>
+        <version>${version.io.opentracing.contrib.opentracing-api-extensions}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentracing.contrib</groupId>
+        <artifactId>opentracing-api-extensions-tracer-spring-autoconfigure</artifactId>
         <version>${version.io.opentracing.contrib.opentracing-api-extensions}</version>
       </dependency>
 
@@ -199,6 +208,7 @@
             <exclude>mvnw.cmd</exclude>
             <exclude>travis/publish.sh</exclude>
             <exclude>.mvn/wrapper/maven-wrapper.properties</exclude>
+            <exclude>**/*.factories</exclude>
           </excludes>
         </configuration>
         <executions>


### PR DESCRIPTION
This PR contains code moved from this PR: https://github.com/opentracing-contrib/java-spring-cloud/pull/15

An example of how it simplifies an example can be seen in this PR: https://github.com/objectiser/opentracing-prometheus-example/pull/13
