### PR TITLE
How about add more Forked VM when run all tests in build

### DIFF
--- a/opentracing-metrics-prometheus-spring-autoconfigure/pom.xml
+++ b/opentracing-metrics-prometheus-spring-autoconfigure/pom.xml
@@ -80,7 +80,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.21.0</version>
         <configuration>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
         </configuration>
       </plugin>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
